### PR TITLE
fix: removed ts path alias for css module stylesheets

### DIFF
--- a/app/features/about/about.tsx
+++ b/app/features/about/about.tsx
@@ -1,4 +1,4 @@
-import styles from "features/about/about.module.css";
+import styles from "./about.module.css";
 import { Grid } from "features/about/grid/grid";
 import { Background } from "features/about/background/background";
 export const About = () => {

--- a/app/features/about/background/background.tsx
+++ b/app/features/about/background/background.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import styles from "features/about/background/background.module.css";
+import styles from "./background.module.css";
 import { InstancedMesh, Object3D } from "three";
 import React, { useMemo, useRef } from "react";
 import { Canvas, useFrame } from "@react-three/fiber";

--- a/app/features/about/card/card.tsx
+++ b/app/features/about/card/card.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from "react";
-import styles from "features/about/card/card.module.css";
+import styles from "./card.module.css";
 
 export const Card = ({ children }: PropsWithChildren) => {
   return <div className={styles.card}>{children}</div>;

--- a/app/features/about/grid/grid.tsx
+++ b/app/features/about/grid/grid.tsx
@@ -1,6 +1,6 @@
 import { getStory } from "@/lib/storyblok-api";
 import { Card } from "features/about/card/card";
-import styles from "features/about/grid/grid.module.css";
+import styles from "./grid.module.css";
 import { Social } from "features/about/social/social";
 import Image from "next/image";
 

--- a/app/features/about/social/social.tsx
+++ b/app/features/about/social/social.tsx
@@ -4,7 +4,7 @@ import {
   faGithub,
 } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import styles from "features/about/social/social.module.css";
+import styles from "./social.module.css";
 import { type IconProp } from "@fortawesome/fontawesome-svg-core";
 import { SocialStoryblok } from "@/types/storyblok";
 

--- a/app/features/work/experience/experience-index.tsx
+++ b/app/features/work/experience/experience-index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import styles from "features/work/experience/experience-index.module.css";
+import styles from "./experience-index.module.css";
 import { ExperienceStoryblok } from "@/types/storyblok";
 
 type ExperienceIndexProps = {

--- a/app/features/work/experience/experience.tsx
+++ b/app/features/work/experience/experience.tsx
@@ -1,5 +1,5 @@
 import { ExperienceStoryblok } from "@/types/storyblok";
-import styles from "features/work/experience/experience.module.css";
+import styles from "./experience.module.css";
 import Image from "next/image";
 
 type ExperienceProps = {

--- a/app/features/work/experience/table.tsx
+++ b/app/features/work/experience/table.tsx
@@ -3,7 +3,7 @@
 import { ExperienceStoryblok } from "@/types/storyblok";
 import { ExperienceItem } from "features/work/experience/experience";
 import { ExperienceIndex } from "features/work/experience/experience-index";
-import styles from "features/work/experience/table.module.css";
+import styles from "./table.module.css";
 import { useState } from "react";
 
 type TableProps = {

--- a/app/features/work/work.tsx
+++ b/app/features/work/work.tsx
@@ -1,4 +1,4 @@
-import styles from "features/work/work.module.css";
+import styles from "./work.module.css";
 import { TableContainer } from "features/work/experience/table-container";
 
 export const Work = () => {


### PR DESCRIPTION
Removed ts path alias for css module stylesheets so `CSS Modules` vs code extension can pick up the code completion